### PR TITLE
travis: Also cache apt packages to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ env:
 
 cache:
   directories:
-  - ${KF5_INSTALL_DIR}
-
+    - ${KF5_INSTALL_DIR}
+    - /var/cache/apt/archives
 
 before_install:
   # Update CMake


### PR DESCRIPTION
Launchpad is very slow, so caching the packages can actually speed up the builds much.